### PR TITLE
Fix OpenAPI server prefix + home coming soon cards

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -31,12 +31,28 @@ export default function Home() {
           </span>
         </Link>
 
-        <section className="flex items-center justify-center rounded-lg border border-dashed p-4">
-          <span className="text-muted-foreground text-xs">Coming soon</span>
+        <section className="flex flex-col gap-3 rounded-lg border border-dashed p-4">
+          <div>
+            <h2 className="mb-2 font-medium text-sm">
+              AI generated Excalidraw diagrams
+            </h2>
+            <p className="text-muted-foreground text-xs">Coming soon</p>
+          </div>
+          <span className="inline-flex items-center justify-center gap-2 rounded-md bg-muted px-4 py-2 font-[family-name:var(--font-caveat)] text-lg text-muted-foreground">
+            Coming soon
+          </span>
         </section>
 
-        <section className="flex items-center justify-center rounded-lg border border-dashed p-4">
-          <span className="text-muted-foreground text-xs">Coming soon</span>
+        <section className="flex flex-col gap-3 rounded-lg border border-dashed p-4">
+          <div>
+            <h2 className="mb-2 font-medium text-sm">
+              Opencode plugin for bi-directional HITL
+            </h2>
+            <p className="text-muted-foreground text-xs">Coming soon</p>
+          </div>
+          <span className="inline-flex items-center justify-center gap-2 rounded-md bg-muted px-4 py-2 font-[family-name:var(--font-caveat)] text-lg text-muted-foreground">
+            Coming soon
+          </span>
         </section>
       </div>
     </div>

--- a/apps/web/src/lib/orpc/openapi.ts
+++ b/apps/web/src/lib/orpc/openapi.ts
@@ -19,6 +19,7 @@ export async function getOpenApiSpec() {
       version: "1.0.0",
       description: "Generate, modify, parse, and share Excalidraw diagrams.",
     },
+    servers: [{ url: "/api" }],
   });
 
   return cachedSpec;


### PR DESCRIPTION
## Summary\n- add /api server prefix to OpenAPI spec so Scalar hits correct endpoints\n- replace home coming-soon placeholders with disabled cards for upcoming features\n\n## Testing\n- The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 19.
Checked 123 files in 35ms. No fixes applied.
Found 39 errors. (failed: existing issues in repo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced homepage grid sections with improved visual structure, including headings and organized content blocks for 'Coming soon' announcements.

* **Chores**
  * Updated API specification configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->