### PR TITLE
Fix: retry Browserbase Stagehand init

### DIFF
--- a/tests/e2e/src/runner/config.ts
+++ b/tests/e2e/src/runner/config.ts
@@ -14,6 +14,7 @@ export interface StagehandRunConfig {
   vercelBypassSecret?: string;
   browserbaseApiKey?: string;
   browserbaseProjectId?: string;
+  browserbaseRegion?: string;
   headless: boolean;
   chromePath?: string;
   screenshotsEnabled: boolean;
@@ -71,6 +72,9 @@ export function loadConfig(): StagehandRunConfig {
     visionModelName,
     browserbaseApiKey: firstEnv("BROWSERBASE_API_KEY"),
     browserbaseProjectId: firstEnv("BROWSERBASE_PROJECT_ID"),
+    browserbaseRegion:
+      firstEnv("BROWSERBASE_REGION", "STAGEHAND_BROWSERBASE_REGION") ||
+      undefined,
     headless: parseBoolean(firstEnv("STAGEHAND_HEADLESS"), true),
     chromePath,
     screenshotsEnabled: parseBoolean(firstEnv("STAGEHAND_SCREENSHOTS"), true),


### PR DESCRIPTION
- retry Stagehand init on Browserbase websocket handshake failures\n- allow optional Browserbase region override via env\n- keep existing LOCAL behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Browserbase region configuration setting.

* **Improvements**
  * Implemented automatic retry mechanism for initialization with improved handling of transient connection failures. System now automatically retries up to 3 attempts and gracefully manages temporary network issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->