### PR TITLE
Fix: address CodeRabbit feedback

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -6,11 +6,11 @@
   "dependencies": {
     "@opencode-ai/plugin": "1.1.41",
     "@opencode-ai/sdk": "1.1.41",
-    "parquetjs-lite": "^0.8.7",
-    "playwright": "^1.58.0"
+    "parquetjs-lite": "^0.8.7"
   },
   "devDependencies": {
-    "bun-types": "latest",
+    "bun-types": "1.3.6",
+    "playwright": "^1.58.0",
     "typescript": "^5.8.2"
   }
 }

--- a/.opencode/tests/opencode-e2e.ts
+++ b/.opencode/tests/opencode-e2e.ts
@@ -3,6 +3,7 @@ import { createServer } from "node:net";
 import { existsSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import assert from "node:assert/strict";
 
 const HOST = "127.0.0.1";
@@ -122,12 +123,15 @@ async function run() {
   const logDir = resolve(process.cwd(), "sketchi", "opencode-logs");
   const port = await findOpenPort();
   const baseUrl = `http://${HOST}:${port}`;
+  const serveScript = fileURLToPath(
+    new URL("../scripts/opencode-serve.ts", import.meta.url)
+  );
 
   console.log("Starting OpenCode server...");
   const serveProcess = Bun.spawn({
     cmd: [
       "bun",
-      "scripts/opencode-serve.ts",
+      serveScript,
       "--project-dir",
       ".",
       "--no-open",

--- a/.opencode/tests/plugin-scenarios.ts
+++ b/.opencode/tests/plugin-scenarios.ts
@@ -29,9 +29,11 @@ function createContext(): ToolContext {
 }
 
 async function assertPngPath(path: string) {
-  assert.ok(path.includes(`${resolve(process.cwd())}/sketchi/png/`));
-  assert.ok(existsSync(path));
-  const info = await stat(path);
+  const pngRoot = resolve(process.cwd(), "sketchi", "png");
+  const normalized = resolve(path);
+  assert.ok(normalized.startsWith(pngRoot));
+  assert.ok(existsSync(normalized));
+  const info = await stat(normalized);
   assert.ok(info.size > 0);
 }
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ For AI features and testing, see `.env.e2e.example` for additional variables.
 
 ## OpenCode Plugin
 
-The OpenCode plugin lives under `.opencode/plugins/sketchi` and calls the production API by default (`https://www.sketchi.app`).
+The OpenCode plugin lives under `.opencode/plugins/sketchi` and calls the production API by default (`https://sketchi.app`).
 
 Notes:
 - OpenCode runs `bun install` in `.opencode`, but you still need Playwright browsers once per machine:
@@ -223,6 +223,7 @@ Notes:
 - Start OpenCode web UI + event logging: `bun run opencode:serve` (logs to `./sketchi/opencode-logs/*.parquet`).
 - DuckDB example (explicit column list, newest log file):
 ```bash
+# Run at least once to generate logs: bun run opencode:serve
 duckdb -c "SELECT receivedAt, directory, eventType, eventStream, sessionID, messageID, parentMessageID, partID, partType, kind, toolName, toolStatus, toolCallID, toolStartMs, toolEndMs, toolDurationMs, role, providerID, modelID, messageCreatedMs, messageCompletedMs, stepCost, stepStartMs, stepEndMs, stepDurationMs, tokensInput, tokensOutput, tokensReasoning, tokensCacheRead, tokensCacheWrite, traceId, data FROM read_parquet('$(ls -t sketchi/opencode-logs/*.parquet | head -n 1)') ORDER BY receivedAt DESC LIMIT 200;"
 ```
 


### PR DESCRIPTION
## Summary
- add per-attempt timeout to OpenCode server readiness probe
- normalize OpenCode e2e script path + PNG path checks
- align OpenCode docs/package deps with canonical domain + dev deps

## Testing
-  (fails: Could not resolve ultracite/biome/core)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API endpoint base URL to use correct domain.

* **Documentation**
  * Added instruction to generate logs using opencode:serve command.
  * Expanded DuckDB example with log generation and parquet file query snippet.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->