### PR TITLE
Fix: skip CI for bump PRs

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -74,19 +74,18 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      - name: Configure deploy key
-        if: steps.skip_release.outputs.skip != 'true'
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.RELEASE_DEPLOY_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git remote set-url origin git@github.com:${{ github.repository }}.git
-
       - name: Get current version
         id: current_version
         if: steps.skip_release.outputs.skip != 'true'
         run: echo "version=$(bun -e "console.log(require('./package.json').version)")" >> $GITHUB_OUTPUT
+
+      - name: Create bump branch
+        id: bump_branch
+        if: steps.skip_release.outputs.skip != 'true'
+        run: |
+          BRANCH="chore/bump-version"
+          git checkout -B "$BRANCH"
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
       - name: Bump version
         id: bump_version
@@ -111,7 +110,59 @@ jobs:
         run: |
           git add package.json
           git commit -m "chore: bump version to ${{ steps.bump_version.outputs.new_version }} [skip-release] [skip ci]"
-          GIT_SSH_COMMAND="ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes" git push origin HEAD:main
+          git push --force --set-upstream origin "${{ steps.bump_branch.outputs.branch }}"
+
+      - name: Create or update PR
+        id: bump_pr
+        if: steps.skip_release.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_TITLE="chore: bump version to ${{ steps.bump_version.outputs.new_version }}"
+          PR_BODY="Automated patch version bump."
+          BRANCH="${{ steps.bump_branch.outputs.branch }}"
+          if gh pr view "$BRANCH" --repo "$GITHUB_REPOSITORY" --json url -q .url > /dev/null 2>&1; then
+            PR_URL=$(gh pr view "$BRANCH" --repo "$GITHUB_REPOSITORY" --json url -q .url)
+            gh pr edit "$PR_URL" --title "$PR_TITLE" --body "$PR_BODY"
+          else
+            PR_URL=$(gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$BRANCH" \
+              --title "$PR_TITLE" \
+              --body "$PR_BODY")
+          fi
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+
+      - name: Enable auto-merge
+        if: steps.skip_release.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ steps.bump_pr.outputs.pr_url }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --squash \
+            --auto
+
+      - name: Wait for PR merge
+        if: steps.skip_release.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL="${{ steps.bump_pr.outputs.pr_url }}"
+          for _ in {1..30}; do
+            MERGED_AT=$(gh pr view "$PR_URL" --repo "$GITHUB_REPOSITORY" --json mergedAt -q .mergedAt)
+            if [ -n "$MERGED_AT" ] && [ "$MERGED_AT" != "null" ]; then
+              echo "PR merged at $MERGED_AT"
+              git fetch origin main
+              git checkout main
+              git reset --hard origin/main
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "PR did not merge in time."
+          exit 1
 
       - name: Generate release notes
         id: release_notes

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -23,6 +23,14 @@ on:
 
 jobs:
   convex-tests:
+    if: |
+      (github.event_name != 'pull_request' || (
+        !startsWith(github.event.pull_request.title, 'chore: bump version') &&
+        !startsWith(github.event.pull_request.head.ref, 'chore/bump-version')
+      )) &&
+      (github.event_name != 'push' || (
+        !contains(github.event.head_commit.message, 'chore: bump version')
+      ))
     runs-on: ubuntu-latest
     env:
       AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}

--- a/.github/workflows/e2e-api.yml
+++ b/.github/workflows/e2e-api.yml
@@ -54,7 +54,16 @@ jobs:
               core.setOutput("run_tests", "true");
               return;
             }
-            const prNumber = prs[0].number;
+            const pr = prs[0];
+            const prNumber = pr.number;
+            const isBumpPr =
+              pr.title?.startsWith("chore: bump version") ||
+              pr.head?.ref?.startsWith("chore/bump-version");
+            if (isBumpPr) {
+              core.notice("Bump PR detected; skipping E2E API tests.");
+              core.setOutput("run_tests", "false");
+              return;
+            }
             const files = await github.paginate(
               github.rest.pulls.listFiles,
               { owner, repo, pull_number: prNumber, per_page: 100 }

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -54,7 +54,16 @@ jobs:
               core.setOutput("run_tests", "true");
               return;
             }
-            const prNumber = prs[0].number;
+            const pr = prs[0];
+            const prNumber = pr.number;
+            const isBumpPr =
+              pr.title?.startsWith("chore: bump version") ||
+              pr.head?.ref?.startsWith("chore/bump-version");
+            if (isBumpPr) {
+              core.notice("Bump PR detected; skipping E2E web tests.");
+              core.setOutput("run_tests", "false");
+              return;
+            }
             const files = await github.paginate(
               github.rest.pulls.listFiles,
               { owner, repo, pull_number: prNumber, per_page: 100 }


### PR DESCRIPTION
- keep bump PR flow (no direct pushes to main)\n- skip CI/e2e for bump PRs by title/branch checks\n- still auto-merge bump PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use a pull request-based process for version bumps, replacing direct pushes to main.
  * Added conditional skipping of automated tests during version bump operations to avoid redundant test runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->