### PR TITLE
Fix opencode file attachment URLs

### DIFF
--- a/.opencode/plugins/sketchi/lib/grade.ts
+++ b/.opencode/plugins/sketchi/lib/grade.ts
@@ -1,4 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin";
+import { pathToFileURL } from "node:url";
 import { buildDefaultPngPath, resolveOutputPath, writePng } from "./output";
 import {
   extractShareLink,
@@ -34,6 +35,18 @@ export type DiagramGradeResult = {
   grade: Record<string, unknown>;
   raw: string;
 };
+
+function toAttachmentUrl(value: string): string {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:" || parsed.protocol === "file:") {
+      return parsed.href;
+    }
+  } catch {
+    // Fall through to treat as a file path.
+  }
+  return pathToFileURL(value).href;
+}
 
 function buildGradePrompt(input: {
   prompt: string;
@@ -205,7 +218,7 @@ export async function gradeDiagram(
     if (pngPath) {
       parts.push({
         type: "file",
-        url: pngPath,
+        url: toAttachmentUrl(pngPath),
         mime: "image/png",
         filename: "diagram.png",
       });


### PR DESCRIPTION
## Summary\n- convert local png paths to file URLs before sending to OpenCode\n- avoid ERR_INVALID_URL when grading diagrams\n\n## Testing\n- bun --cwd .opencode tests/opencode-e2e.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced attachment URL handling to properly convert file paths to valid URL formats. This improvement ensures attachments are correctly referenced and processed throughout the application, providing more reliable and consistent file attachment functionality and improved handling of local file references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->