### PR TITLE
docs(agents): Vercel/Convex env + pre-push sanity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,8 @@
+## Repo CI / Deploy Note
+- Vercel Preview/Prod: `NEXT_PUBLIC_CONVEX_URL` is set automatically by the Convex deploy step. If it's undefined, the Convex deploy is failing (debug that first).
+- Pre-push sanity: `bun x ultracite fix`, `bun x ultracite check`, `bun run check-types`, `bun run build`, and `cd packages/backend && bunx convex codegen && bun run test`.
 
+---
 
 # Working Preferences
 


### PR DESCRIPTION
Add a small, repo-specific note: Vercel sets NEXT_PUBLIC_CONVEX_URL via the Convex deploy step; if missing, debug convex deploy first. Also lists a short local pre-push sanity checklist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated internal deployment and development guidelines to enhance deployment reliability and code quality validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->