### PR TITLE
fix: unblock opencode next publish bump

### DIFF
--- a/packages/opencode-excalidraw/.mise/tasks/publish
+++ b/packages/opencode-excalidraw/.mise/tasks/publish
@@ -43,7 +43,8 @@ if [ "${TAG}" = "next" ]; then
   echo " > bumping version: ${CURRENT_VERSION} -> ${PRERELEASE_VERSION}"
 
   if [ "${DRY_RUN}" != "true" ]; then
-    npm version "${PRERELEASE_VERSION}" --no-git-tag-version --allow-same-version
+    # npm version fails in this workspace because the root uses Bun catalog protocol.
+    npm pkg set "version=${PRERELEASE_VERSION}"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Replaces `npm version` with `npm pkg set` for `next` prerelease version bumps in plugin publish task.
- Avoids npm workspace parsing failure (`Unsupported URL Type "catalog:"`) in this Bun monorepo.

## Why
`npm version` fails in CI on this repo because the root workspace uses Bun `catalog:` protocol. That broke `next` publishes before auth/OIDC checks.

## Validation
- `bun run --cwd packages/opencode-excalidraw test`
- Confirmed local repro of previous failure with `npm version ...` and that `npm pkg set version=...` works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the prerelease publishing process to enhance build infrastructure stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->