### PR TITLE
fix(ci): use GitHub-hosted runner for opencode publish

### DIFF
--- a/.github/workflows/opencode-excalidraw-publish.yml
+++ b/.github/workflows/opencode-excalidraw-publish.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- switch `opencode-excalidraw-publish` job runner from Blacksmith to `ubuntu-latest`
- restore npm OIDC provenance compatibility for publish jobs (npm rejects provenance from self-hosted runners)
- keep all linked-artifact metadata logic from #160 unchanged

## Validation
- `bun x ultracite check`
- confirmed latest failed publish run (`22461047709`) error: `Unsupported GitHub Actions runner environment: "self-hosted"`