### PR TITLE
fix(ci): retry linked artifact metadata lookup after publish

### DIFF
--- a/.github/workflows/opencode-excalidraw-publish.yml
+++ b/.github/workflows/opencode-excalidraw-publish.yml
@@ -254,20 +254,33 @@ jobs:
             '
           })"
 
-          gh api "orgs/${OWNER}/artifacts/${DIGEST}/metadata/storage-records" >/tmp/opencode-excalidraw-storage-records.json
-          RECORD_COUNT="$({
-            node -e '
-              const fs = require("fs");
-              const j = JSON.parse(fs.readFileSync("/tmp/opencode-excalidraw-storage-records.json", "utf8"));
-              const count = Number(j.total_count ?? 0);
-              process.stdout.write(String(count));
-            '
-          })"
+          RECORD_COUNT="0"
+          for i in $(seq 1 20); do
+            if gh api "orgs/${OWNER}/artifacts/${DIGEST}/metadata/storage-records" >/tmp/opencode-excalidraw-storage-records.json 2>/tmp/opencode-excalidraw-storage-records.err; then
+              RECORD_COUNT="$({
+                node -e '
+                  const fs = require("fs");
+                  const j = JSON.parse(fs.readFileSync("/tmp/opencode-excalidraw-storage-records.json", "utf8"));
+                  const count = Number(j.total_count ?? 0);
+                  process.stdout.write(String(count));
+                '
+              })"
+              if [ "${RECORD_COUNT}" -ge 1 ]; then
+                break
+              fi
+            fi
 
-          if [ "${RECORD_COUNT}" -lt 1 ]; then
-            echo "[ERROR] linked artifact storage record not found for ${DIGEST}"
-            exit 1
-          fi
+            if [ "$i" -eq 20 ]; then
+              echo "[ERROR] linked artifact storage record not found for ${DIGEST}"
+              if [ -s /tmp/opencode-excalidraw-storage-records.err ]; then
+                cat /tmp/opencode-excalidraw-storage-records.err
+              fi
+              exit 1
+            fi
+
+            echo "Waiting for linked artifact storage record indexing (${i}/20)..."
+            sleep 3
+          done
 
           {
             echo "## OpenCode Excalidraw Artifact Metadata"


### PR DESCRIPTION
## Summary
- add retry logic when reading `orgs/{org}/artifacts/{digest}/metadata/storage-records` in `opencode-excalidraw-publish`
- handle artifact-metadata API indexing lag that can return transient `404 no artifacts found` immediately after record creation
- keep npm publish behavior unchanged (`0.0.6` release remains published successfully)

## Context
The `0.0.6` publish run succeeded through npm + provenance, but failed in the follow-up linked-artifact verification due to immediate read-after-write timing on the metadata API.

## Validation
- `bun x ultracite check`
- confirmed `@sketchi-app/opencode-excalidraw@0.0.6` is published with OIDC provenance and `latest` now points to `0.0.6`