### PR TITLE
ci(opencode-excalidraw): create GitHub attestation for npm tarball

### DIFF
--- a/.github/workflows/opencode-excalidraw-publish.yml
+++ b/.github/workflows/opencode-excalidraw-publish.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   id-token: write
+  attestations: write
   contents: write
 
 jobs:
@@ -290,4 +291,23 @@ jobs:
             echo "- Tarball: ${TARBALL_URL}"
           } >> "$GITHUB_STEP_SUMMARY"
 
+          echo "OPENCODE_TARBALL_URL=${TARBALL_URL}" >> "$GITHUB_ENV"
+          echo "OPENCODE_STORAGE_DIGEST=${DIGEST}" >> "$GITHUB_ENV"
+
           echo "✓ linked artifact storage record created"
+
+      - name: Download tarball for GitHub attestation
+        run: |
+          set -euo pipefail
+
+          if [ -z "${OPENCODE_TARBALL_URL:-}" ]; then
+            echo "[ERROR] missing OPENCODE_TARBALL_URL"
+            exit 1
+          fi
+
+          curl -fsSL "${OPENCODE_TARBALL_URL}" -o /tmp/opencode-excalidraw.tgz
+
+      - name: Create GitHub provenance attestation for tarball
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: /tmp/opencode-excalidraw.tgz


### PR DESCRIPTION
## Why
`0.0.6` published successfully with npm OIDC provenance, but linked-artifact SLSA stayed at 0 because we only had metadata API linkage and no GitHub-native attestation for the tarball digest.

## What changed
- grant `attestations: write` in `opencode-excalidraw-publish`
- after linked-artifact storage record creation, download the published npm tarball
- create a GitHub provenance attestation with `actions/attest-build-provenance@v2` on that tarball

## Notes
- this does not require bumping the package version
- future `latest`/`next` publishes will emit both linked artifact metadata and a GitHub attestation for the same tarball

## Validation
- `bun x ultracite check`
- confirmed `@sketchi-app/opencode-excalidraw@0.0.6` is published and linked metadata record exists for digest `sha256:0a2fc564fed5367fa8ceb377e5fb8e7ec5cce9a58d5aa219aad3f418bdf1b12c`