### PR TITLE
fix(opencode-excalidraw): stabilize diagram_grade under real harness

### DIFF
--- a/packages/opencode-excalidraw/README.md
+++ b/packages/opencode-excalidraw/README.md
@@ -21,8 +21,10 @@ npm i @sketchi-app/opencode-excalidraw
 3. Install Playwright browsers once per machine (required for `diagram_to_png`):
 
 ```bash
-npx playwright install
+npx playwright install chromium
 ```
+
+If browsers are missing, PNG-related tools fail fast with this install command. They do not auto-install browser binaries during execution.
 
 ## Usage
 
@@ -33,6 +35,8 @@ The plugin exposes tools:
 - `diagram_restructure`
 - `diagram_to_png`
 - `diagram_grade`
+
+`diagram_grade` is intentionally one-image-per-call. For multiple diagrams, invoke `diagram_grade` in separate follow-up messages.
 
 When this plugin is loaded, it registers a `sketchi-diagram` subagent (without disabling built-in `build`/`plan`) and conditionally injects routing guidance only when the user request mentions `diagram`, `sketchi`, or `excalidraw`, so diagram requests route to `diagram_*` tools instead of defaulting to Mermaid (unless Mermaid is explicitly requested).
 

--- a/packages/opencode-excalidraw/src/index.test.ts
+++ b/packages/opencode-excalidraw/src/index.test.ts
@@ -2,11 +2,50 @@ import { describe, expect, test } from "bun:test";
 
 import SketchiPlugin from "./index";
 
-function createPluginInput() {
+const VALID_GRADE_JSON = JSON.stringify({
+  diagramType: {
+    expected: "architecture",
+    actual: "architecture",
+    matches: true,
+    notes: [],
+  },
+  arrowDirectionality: { score: 4, issues: [] },
+  layout: { score: 4, issues: [] },
+  visualQuality: { score: 4, issues: [] },
+  accuracy: { score: 4, issues: [] },
+  completeness: { score: 4, issues: [] },
+  overallScore: 4,
+  notes: [],
+});
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 1000
+): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function createPluginInput(client: unknown = {}) {
   const cwd = process.cwd();
 
   return {
-    client: {} as never,
+    client: client as never,
     project: {
       id: "test-project",
       name: "test-project",
@@ -16,6 +55,20 @@ function createPluginInput() {
     worktree: cwd,
     serverUrl: new URL("http://localhost:0"),
     $: {} as never,
+  };
+}
+
+function createToolContext(messageID: string) {
+  const cwd = process.cwd();
+  return {
+    sessionID: "session-1",
+    messageID,
+    agent: "build",
+    directory: cwd,
+    worktree: cwd,
+    abort: new AbortController().signal,
+    metadata: () => undefined,
+    ask: async () => undefined,
   };
 }
 
@@ -36,7 +89,7 @@ describe("SketchiPlugin", () => {
         sessionID: "session-1",
         messageID: "message-1",
       },
-      output
+      output as never
     );
 
     const combined = (output.message.system ?? "").toLowerCase();
@@ -61,7 +114,7 @@ describe("SketchiPlugin", () => {
         sessionID: "session-1",
         messageID: "message-2",
       },
-      output
+      output as never
     );
 
     expect(output.message.system).toBeUndefined();
@@ -84,9 +137,9 @@ describe("SketchiPlugin", () => {
     expect(config.agent.build?.description).toBe("default build agent");
     expect(config.agent.plan?.description).toBe("default plan agent");
 
-    const sketchiDiagram = config.agent["sketchi-diagram"] as
-      | Record<string, unknown>
-      | undefined;
+    const sketchiDiagram = (config.agent as Record<string, unknown>)[
+      "sketchi-diagram"
+    ] as Record<string, unknown> | undefined;
 
     expect(sketchiDiagram?.mode).toBe("subagent");
     expect(sketchiDiagram?.hidden).toBe(false);
@@ -103,5 +156,94 @@ describe("SketchiPlugin", () => {
 
     expect(fromPromptDescription?.toLowerCase()).toContain("mermaid");
     expect(tweakDescription?.toLowerCase()).toContain("mermaid");
+  });
+
+  test("diagram_grade blocks concurrent calls for the same message", async () => {
+    const deferred = createDeferred<{
+      data: { parts: Array<{ type: string; text: string }> };
+    }>();
+    const promptCalls: unknown[] = [];
+
+    const plugin = await SketchiPlugin(
+      createPluginInput({
+        session: {
+          prompt: (input: unknown) => {
+            promptCalls.push(input);
+            return deferred.promise;
+          },
+        },
+      })
+    );
+
+    const gradeTool = plugin.tool?.diagram_grade;
+    expect(gradeTool).toBeDefined();
+    if (!gradeTool) {
+      throw new Error("diagram_grade tool missing");
+    }
+
+    const context = createToolContext("message-grade-concurrent");
+    const firstCall = gradeTool.execute(
+      { prompt: "grade first", pngPath: "/tmp/first.png" },
+      context as never
+    );
+
+    await waitFor(() => promptCalls.length === 1);
+
+    await expect(
+      gradeTool.execute(
+        { prompt: "grade second", pngPath: "/tmp/second.png" },
+        context as never
+      )
+    ).rejects.toThrow("one image per message");
+
+    expect(promptCalls.length).toBe(1);
+
+    deferred.resolve({
+      data: {
+        parts: [{ type: "text", text: VALID_GRADE_JSON }],
+      },
+    });
+
+    await expect(firstCall).resolves.toContain('"overallScore": 4');
+  });
+
+  test("diagram_grade allows only one call per message even sequentially", async () => {
+    const promptCalls: unknown[] = [];
+
+    const plugin = await SketchiPlugin(
+      createPluginInput({
+        session: {
+          prompt: (input: unknown) => {
+            promptCalls.push(input);
+            return {
+              data: {
+                parts: [{ type: "text", text: VALID_GRADE_JSON }],
+              },
+            };
+          },
+        },
+      })
+    );
+
+    const gradeTool = plugin.tool?.diagram_grade;
+    expect(gradeTool).toBeDefined();
+    if (!gradeTool) {
+      throw new Error("diagram_grade tool missing");
+    }
+
+    const context = createToolContext("message-grade-sequential");
+    await gradeTool.execute(
+      { prompt: "grade first", pngPath: "/tmp/first.png" },
+      context as never
+    );
+
+    await expect(
+      gradeTool.execute(
+        { prompt: "grade second", pngPath: "/tmp/second.png" },
+        context as never
+      )
+    ).rejects.toThrow("one image per message");
+
+    expect(promptCalls.length).toBe(1);
   });
 });

--- a/packages/opencode-excalidraw/src/lib/agent-hints.test.ts
+++ b/packages/opencode-excalidraw/src/lib/agent-hints.test.ts
@@ -19,6 +19,8 @@ describe("sketchi-diagram hints", () => {
     expect(hints).toContain("diagram_grade");
     expect(hints).toContain("instead of writing mermaid");
     expect(hints).toContain("explicitly asks for mermaid");
+    expect(hints).toContain("do not run install commands automatically");
+    expect(hints).toContain("one diagram_grade call per assistant message");
   });
 
   test("system hint append does not duplicate hints", () => {

--- a/packages/opencode-excalidraw/src/lib/agent-hints.ts
+++ b/packages/opencode-excalidraw/src/lib/agent-hints.ts
@@ -4,6 +4,8 @@ const SKETCHI_DIAGRAM_AGENT_HINTS = [
   "When diagram_* tools are available and the request is diagram-related, call diagram_* tools instead of writing Mermaid.",
   "Only produce Mermaid when the user explicitly asks for Mermaid output.",
   "Tool selection: diagram_from_prompt for new diagrams, diagram_tweak for tactical edits, diagram_restructure for structural edits, diagram_to_png for exports, diagram_grade for evaluation.",
+  "If Playwright browsers are missing, stop and instruct the user to run `npx playwright install chromium`; do not run install commands automatically.",
+  "Use at most one diagram_grade call per assistant message; for multiple diagrams, ask for separate follow-up grading messages.",
   "Save diagram outputs under /sketchi at the project root.",
   "If requirements are unclear, ask one concise clarifying question.",
   "Keep replies concise and execution-focused.",

--- a/packages/opencode-excalidraw/src/lib/grade.test.ts
+++ b/packages/opencode-excalidraw/src/lib/grade.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+
+import { gradeDiagram } from "./grade";
+
+const VALID_GRADE_JSON = JSON.stringify({
+  diagramType: {
+    expected: "architecture",
+    actual: "architecture",
+    matches: true,
+    notes: [],
+  },
+  arrowDirectionality: { score: 4, issues: [] },
+  layout: { score: 4, issues: [] },
+  visualQuality: { score: 4, issues: [] },
+  accuracy: { score: 4, issues: [] },
+  completeness: { score: 4, issues: [] },
+  overallScore: 4,
+  notes: [],
+});
+
+describe("gradeDiagram", () => {
+  test("times out when grading prompt never returns", async () => {
+    const client = {
+      session: {
+        prompt: async () => await new Promise<never>(() => undefined),
+      },
+    } as never;
+
+    await expect(
+      gradeDiagram(
+        client,
+        {
+          sessionID: "session-timeout",
+          messageID: "message-timeout",
+          agent: "build",
+        },
+        {
+          prompt: "grade this",
+          apiBase: "https://sketchi.app",
+          baseDir: process.cwd(),
+          pngPath: "/tmp/diagram-timeout.png",
+          promptTimeoutMs: 1000,
+          renderOptions: {},
+        }
+      )
+    ).rejects.toThrow("timed out after 1000ms");
+  });
+
+  test("parses JSON grade response when prompt succeeds", async () => {
+    const client = {
+      session: {
+        prompt: async () => ({
+          parts: [{ type: "text", text: VALID_GRADE_JSON }],
+        }),
+      },
+    } as never;
+
+    const result = await gradeDiagram(
+      client,
+      {
+        sessionID: "session-success",
+        messageID: "message-success",
+        agent: "build",
+      },
+      {
+        prompt: "grade this",
+        apiBase: "https://sketchi.app",
+        baseDir: process.cwd(),
+        pngPath: "/tmp/diagram-success.png",
+        promptTimeoutMs: 1000,
+        renderOptions: {},
+      }
+    );
+
+    expect(result.pngPath).toBe("/tmp/diagram-success.png");
+    expect(result.grade.overallScore).toBe(4);
+  });
+
+  test("uses dedicated grader session when session.create is available", async () => {
+    let createCallCount = 0;
+    const promptCalls: Array<{
+      path: { id: string };
+      body: { messageID?: string };
+    }> = [];
+
+    const client = {
+      session: {
+        create: () => {
+          createCallCount += 1;
+          return Promise.resolve({ data: { id: "grader-session-1" } });
+        },
+        prompt: (input: {
+          path: { id: string };
+          body: { messageID?: string };
+        }) => {
+          promptCalls.push(input);
+          return Promise.resolve({
+            parts: [{ type: "text", text: VALID_GRADE_JSON }],
+          });
+        },
+      },
+    } as never;
+
+    const firstResult = await gradeDiagram(
+      client,
+      {
+        sessionID: "parent-session-1",
+        messageID: "message-a",
+        agent: "build",
+      },
+      {
+        prompt: "grade this",
+        apiBase: "https://sketchi.app",
+        baseDir: process.cwd(),
+        pngPath: "/tmp/diagram-a.png",
+        promptTimeoutMs: 1000,
+        renderOptions: {},
+      }
+    );
+
+    const secondResult = await gradeDiagram(
+      client,
+      {
+        sessionID: "parent-session-1",
+        messageID: "message-b",
+        agent: "build",
+      },
+      {
+        prompt: "grade this again",
+        apiBase: "https://sketchi.app",
+        baseDir: process.cwd(),
+        pngPath: "/tmp/diagram-b.png",
+        promptTimeoutMs: 1000,
+        renderOptions: {},
+      }
+    );
+
+    expect(firstResult.grade.overallScore).toBe(4);
+    expect(secondResult.grade.overallScore).toBe(4);
+    expect(createCallCount).toBe(1);
+    expect(promptCalls.length).toBe(2);
+    expect(promptCalls[0]?.path.id).toBe("grader-session-1");
+    expect(promptCalls[1]?.path.id).toBe("grader-session-1");
+    expect(promptCalls[0]?.body.messageID).toBeUndefined();
+    expect(promptCalls[1]?.body.messageID).toBeUndefined();
+  });
+});

--- a/packages/opencode-excalidraw/src/lib/render.test.ts
+++ b/packages/opencode-excalidraw/src/lib/render.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { mapPlaywrightLaunchError } from "./render";
+
+describe("mapPlaywrightLaunchError", () => {
+  test("maps missing browser launch failure to actionable message", () => {
+    const mapped = mapPlaywrightLaunchError(
+      new Error(
+        "launch: Executable doesn't exist at /tmp/chrome-headless-shell"
+      )
+    );
+
+    expect(mapped).not.toBeNull();
+    expect(mapped?.message).toContain("npx playwright install chromium");
+    expect(mapped?.message).toContain("does not auto-install");
+  });
+
+  test("leaves unrelated launch errors unchanged", () => {
+    const mapped = mapPlaywrightLaunchError(new Error("network timeout"));
+    expect(mapped).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- fix `diagram_grade` response parsing to read top-level `parts` from SDK `responseStyle: "data"` and keep defensive fallback handling
- add bounded timeout/session behavior and one-grade-per-message guard to avoid hangs and re-entrancy during warm-thread grading
- improve Playwright fail-fast messaging (no auto-install side effects), update docs/agent hints, and add targeted tests for grading/render behavior

## Validation
- bun run --cwd packages/opencode-excalidraw test
- bun run --cwd packages/opencode-excalidraw typecheck
- bun run --cwd packages/opencode-excalidraw build
- bun x ultracite check packages/opencode-excalidraw/src packages/opencode-excalidraw/README.md
- harness: runs/run-grade-size-matrix.sh
- harness: runs/run-warm-grade-sequential.sh
- coderabbit review --plain -t uncommitted (No findings)