### PR TITLE
fix(web): prevent profile menu crash in production

### DIFF
--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -20,6 +20,7 @@ import { ModeToggle } from "./mode-toggle";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -59,14 +60,16 @@ export default function Header() {
           align="end"
           className="w-56 min-w-[14rem] rounded-xl p-1"
         >
-          <DropdownMenuLabel className="px-3 py-2">
-            <div className="truncate font-medium text-foreground text-xs">
-              {displayName}
-            </div>
-            <div className="truncate text-[11px] text-muted-foreground">
-              {identity.email ?? "Signed in"}
-            </div>
-          </DropdownMenuLabel>
+          <DropdownMenuGroup>
+            <DropdownMenuLabel className="px-3 py-2">
+              <div className="truncate font-medium text-foreground text-xs">
+                {displayName}
+              </div>
+              <div className="truncate text-[11px] text-muted-foreground">
+                {identity.email ?? "Signed in"}
+              </div>
+            </DropdownMenuLabel>
+          </DropdownMenuGroup>
 
           <DropdownMenuSeparator />
 


### PR DESCRIPTION
## Summary
- Fix the profile dropdown crash by wrapping `DropdownMenuLabel` in `DropdownMenuGroup` so Base UI menu context is valid.
- This resolves `Base UI error #31` triggered when opening the authenticated profile menu.

## Notes
- Console `/_vercel/insights/script.js` `ERR_BLOCKED_BY_CLIENT` is typically from ad blockers and is non-fatal.

## Validation
- `bun x ultracite check`
- `cd apps/web && bunx tsc --noEmit`