### PR TITLE
ci: publish opencode next on every iteration

### DIFF
--- a/.github/workflows/opencode-excalidraw-release.yml
+++ b/.github/workflows/opencode-excalidraw-release.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       releases_created: ${{ steps.release_please.outputs.releases_created }}
-      prs_created: ${{ steps.release_please.outputs.prs_created == 'true' && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,7 +38,7 @@ jobs:
   dispatch-publish:
     needs: process
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    if: needs.process.outputs.releases_created == 'true' || needs.process.outputs.prs_created == 'true'
+    if: needs.process.result == 'success'
     steps:
       - name: Dispatch publish for releases
         if: needs.process.outputs.releases_created == 'true'
@@ -50,7 +49,7 @@ jobs:
           client-payload: '{"tag":"latest"}'
 
       - name: Dispatch publish for prerelease
-        if: needs.process.outputs.prs_created == 'true'
+        if: needs.process.outputs.releases_created != 'true'
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Notes:
   - `npx playwright install`
 - Override API base with `SKETCHI_API_URL`.
 - Tools exposed: `diagram_from_prompt`, `diagram_tweak`, `diagram_restructure`, `diagram_to_png`, `diagram_grade`.
+- Publish channels: `next` is used for pre-release iteration testing; `latest` publishes when the plugin release PR is merged.
 - Install and use from any repo:
 ```bash
 npm i @sketchi-app/opencode-excalidraw

--- a/packages/opencode-excalidraw/README.md
+++ b/packages/opencode-excalidraw/README.md
@@ -60,6 +60,19 @@ Optional env-based auth fallback (used when OpenCode auth is not configured):
 - Fast package tests: `bun run test`
 - Optional live integration scenario (calls Sketchi API and renders PNG): `bun run test:integration`
 
+## Release Channels
+
+Plugin publishing uses two channels:
+
+- `next`: published for plugin iterations on `main` when a formal release was not created.
+- `latest`: published only when release-please creates an actual release (after merging the release PR).
+
+Practical flow:
+
+1. Keep the release PR open while validating behavior via real OpenCode install/upgrade cycles.
+2. Consume `next` builds for validation.
+3. Merge the release PR when ready to promote that version to `latest`.
+
 ## Links
 
 - npm: https://www.npmjs.com/package/@sketchi-app/opencode-excalidraw


### PR DESCRIPTION
Closes #184

## Summary
- update `opencode-excalidraw-release` dispatch logic so plugin iterations always publish `next`
- keep `latest` publish gated to actual release creation
- document release-channel behavior in plugin docs and root README

## Why
Release PRs can stay open for multiple iteration cycles (`next.x`) before a public release. Previous logic only dispatched `next` on release PR creation (`prs_created == true`), which could skip expected prerelease publishes while iterating on an already-open release PR.

## Changes
- `.github/workflows/opencode-excalidraw-release.yml`
  - removed dependence on `prs_created`
  - dispatch job now runs on successful `process`
  - dispatch rules:
    - `releases_created == true` -> publish `latest`
    - otherwise -> publish `next`
- `packages/opencode-excalidraw/README.md`
  - added explicit `next` vs `latest` release-channel behavior and practical flow
- `README.md`
  - added OpenCode plugin release-channel note

## Validation
- `bun x ultracite check` passed
- Verified current release/publish chain behavior on `main`:
  - release PR merge produced `opencode-excalidraw-v0.0.8`
  - publish run completed successfully
  - npm now reports `latest=0.0.8`
