### PR TITLE
fix: harden opencode output path policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,7 @@ temp
 /.codex/environments/
 
 # Opencode plugin
-/sketchi/png/
-/sketchi/*.png
+/.sketchi/
 /sketchi/opencode-logs/
 /sketchi/opencode-logs*/
 opencode-logs/

--- a/packages/opencode-excalidraw/README.md
+++ b/packages/opencode-excalidraw/README.md
@@ -45,6 +45,7 @@ When this plugin is loaded, it registers a `sketchi-diagram` subagent (without d
 Optional env override:
 
 - `SKETCHI_API_URL` (defaults to `https://sketchi.app`)
+- `SKETCHI_ALLOW_UNSAFE_OUTPUT_PATH=1` to opt out of default output-path containment (power users only)
 
 Authentication is required for diagram APIs. In OpenCode, select auth provider `sketchi`:
 
@@ -54,6 +55,21 @@ Authentication is required for diagram APIs. In OpenCode, select auth provider `
 Optional env-based auth fallback (used when OpenCode auth is not configured):
 
 - `SKETCHI_ACCESS_TOKEN` or `SKETCHI_BEARER_TOKEN` (OAuth bearer token)
+
+## Output Paths
+
+PNG outputs are session-scoped by default:
+
+- root: `/.sketchi/sessions/<opencode-session-id>/png/`
+- auto-generated files (`diagram_from_prompt`, `diagram_tweak`, `diagram_restructure`, `diagram_to_png`, `diagram_grade`) are written under this root
+- tool-provided `outputPath` values are constrained to this root by default
+
+Examples:
+
+- `outputPath: "foo.png"` -> `/.sketchi/sessions/<sessionID>/png/foo.png`
+- `outputPath: "exports/foo.png"` -> `/.sketchi/sessions/<sessionID>/png/exports/foo.png`
+
+Traversal attempts and absolute paths outside the session root are rejected unless `SKETCHI_ALLOW_UNSAFE_OUTPUT_PATH=1` is set.
 
 ## Testing
 

--- a/packages/opencode-excalidraw/scripts/integration-plugin-scenarios.ts
+++ b/packages/opencode-excalidraw/scripts/integration-plugin-scenarios.ts
@@ -1,7 +1,7 @@
 // Scenario:
-// 1) diagram_from_prompt -> expect shareLink + PNG under ./sketchi/png
+// 1) diagram_from_prompt -> expect shareLink + PNG under ./.sketchi/sessions/<sessionID>/png
 // 2) diagram_tweak (same session + request) -> expect same session continuity + PNG
-// 3) diagram_to_png (shareUrl) -> expect PNG under ./sketchi/png
+// 3) diagram_to_png (shareUrl) -> expect PNG under ./.sketchi/sessions/<sessionID>/png
 import { existsSync } from "node:fs";
 import { stat } from "node:fs/promises";
 import { resolve } from "node:path";
@@ -35,7 +35,13 @@ async function assertPngPath(path: string) {
   if (SKIP_PNG_RENDER) {
     return;
   }
-  const pngRoot = resolve(process.cwd(), "sketchi", "png");
+  const pngRoot = resolve(
+    process.cwd(),
+    ".sketchi",
+    "sessions",
+    "test-session",
+    "png"
+  );
   const normalized = resolve(path);
   if (!normalized.startsWith(pngRoot)) {
     throw new Error(`PNG path must stay under ${pngRoot}: ${normalized}`);

--- a/packages/opencode-excalidraw/src/index.ts
+++ b/packages/opencode-excalidraw/src/index.ts
@@ -21,6 +21,8 @@ const GRADE_CALL_STATE_LIMIT = 2048;
 const SKETCHI_SESSION_CACHE_LIMIT = 2048;
 const DEFAULT_THREAD_RUN_TIMEOUT_MS = 180_000;
 const SKIP_PNG_RENDER = process.env.SKETCHI_SKIP_PNG_RENDER === "1";
+const ALLOW_UNSAFE_OUTPUT_PATH =
+  process.env.SKETCHI_ALLOW_UNSAFE_OUTPUT_PATH === "1";
 const gradeCallStateByMessage = new Map<string, "running" | "completed">();
 const sketchiSessionByOpenCodeSession = new Map<string, string>();
 
@@ -389,7 +391,9 @@ export const SketchiPlugin: Plugin = (input) => {
           outputPath: tool.schema
             .string()
             .optional()
-            .describe("Optional PNG output path"),
+            .describe(
+              "Optional PNG output path under .sketchi/sessions/<sessionID>/png (set SKETCHI_ALLOW_UNSAFE_OUTPUT_PATH=1 to allow paths outside this root)"
+            ),
           scale: tool.schema
             .number()
             .optional()
@@ -444,8 +448,19 @@ export const SketchiPlugin: Plugin = (input) => {
           cacheSketchiSession(context.sessionID, runResult.sessionId);
 
           const outputPath = args.outputPath
-            ? resolveOutputPath(args.outputPath, context.directory)
-            : buildDefaultPngPath("diagram-generate", context.directory);
+            ? resolveOutputPath(
+                args.outputPath,
+                context.directory,
+                context.sessionID,
+                {
+                  allowUnsafeOutputPath: ALLOW_UNSAFE_OUTPUT_PATH,
+                }
+              )
+            : buildDefaultPngPath(
+                "diagram-generate",
+                context.directory,
+                context.sessionID
+              );
 
           try {
             if (SKIP_PNG_RENDER) {
@@ -554,7 +569,9 @@ export const SketchiPlugin: Plugin = (input) => {
           outputPath: tool.schema
             .string()
             .optional()
-            .describe("Optional PNG output path"),
+            .describe(
+              "Optional PNG output path under .sketchi/sessions/<sessionID>/png (set SKETCHI_ALLOW_UNSAFE_OUTPUT_PATH=1 to allow paths outside this root)"
+            ),
           scale: tool.schema
             .number()
             .optional()
@@ -638,8 +655,19 @@ export const SketchiPlugin: Plugin = (input) => {
           cacheSketchiSession(context.sessionID, runResult.sessionId);
 
           const outputPath = args.outputPath
-            ? resolveOutputPath(args.outputPath, context.directory)
-            : buildDefaultPngPath("diagram-tweak", context.directory);
+            ? resolveOutputPath(
+                args.outputPath,
+                context.directory,
+                context.sessionID,
+                {
+                  allowUnsafeOutputPath: ALLOW_UNSAFE_OUTPUT_PATH,
+                }
+              )
+            : buildDefaultPngPath(
+                "diagram-tweak",
+                context.directory,
+                context.sessionID
+              );
 
           try {
             if (SKIP_PNG_RENDER) {
@@ -750,7 +778,9 @@ export const SketchiPlugin: Plugin = (input) => {
           outputPath: tool.schema
             .string()
             .optional()
-            .describe("Optional PNG output path"),
+            .describe(
+              "Optional PNG output path under .sketchi/sessions/<sessionID>/png (set SKETCHI_ALLOW_UNSAFE_OUTPUT_PATH=1 to allow paths outside this root)"
+            ),
           scale: tool.schema
             .number()
             .optional()
@@ -834,8 +864,19 @@ export const SketchiPlugin: Plugin = (input) => {
           cacheSketchiSession(context.sessionID, runResult.sessionId);
 
           const outputPath = args.outputPath
-            ? resolveOutputPath(args.outputPath, context.directory)
-            : buildDefaultPngPath("diagram-restructure", context.directory);
+            ? resolveOutputPath(
+                args.outputPath,
+                context.directory,
+                context.sessionID,
+                {
+                  allowUnsafeOutputPath: ALLOW_UNSAFE_OUTPUT_PATH,
+                }
+              )
+            : buildDefaultPngPath(
+                "diagram-restructure",
+                context.directory,
+                context.sessionID
+              );
 
           try {
             if (SKIP_PNG_RENDER) {
@@ -929,7 +970,9 @@ export const SketchiPlugin: Plugin = (input) => {
           outputPath: tool.schema
             .string()
             .optional()
-            .describe("Optional PNG output path"),
+            .describe(
+              "Optional PNG output path under .sketchi/sessions/<sessionID>/png (set SKETCHI_ALLOW_UNSAFE_OUTPUT_PATH=1 to allow paths outside this root)"
+            ),
           scale: tool.schema
             .number()
             .optional()
@@ -957,8 +1000,19 @@ export const SketchiPlugin: Plugin = (input) => {
           }
 
           const outputPath = args.outputPath
-            ? resolveOutputPath(args.outputPath, context.directory)
-            : buildDefaultPngPath("diagram-to-png", context.directory);
+            ? resolveOutputPath(
+                args.outputPath,
+                context.directory,
+                context.sessionID,
+                {
+                  allowUnsafeOutputPath: ALLOW_UNSAFE_OUTPUT_PATH,
+                }
+              )
+            : buildDefaultPngPath(
+                "diagram-to-png",
+                context.directory,
+                context.sessionID
+              );
 
           try {
             let shareLink:
@@ -1059,7 +1113,9 @@ export const SketchiPlugin: Plugin = (input) => {
           outputPath: tool.schema
             .string()
             .optional()
-            .describe("Optional path to write PNG (if generated)"),
+            .describe(
+              "Optional path to write PNG under .sketchi/sessions/<sessionID>/png (set SKETCHI_ALLOW_UNSAFE_OUTPUT_PATH=1 to allow paths outside this root)"
+            ),
           scale: tool.schema
             .number()
             .optional()
@@ -1106,6 +1162,7 @@ export const SketchiPlugin: Plugin = (input) => {
                   padding: args.padding,
                   background: args.background,
                 },
+                allowUnsafeOutputPath: ALLOW_UNSAFE_OUTPUT_PATH,
                 apiBase,
                 baseDir: context.directory,
                 abort: context.abort,

--- a/packages/opencode-excalidraw/src/lib/grade.ts
+++ b/packages/opencode-excalidraw/src/lib/grade.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { PluginInput } from "@opencode-ai/plugin";
 
@@ -18,6 +19,7 @@ import { resolveExcalidrawFromShareUrl } from "./resolve-share-url";
 
 export interface DiagramGradeInput {
   abort?: AbortSignal;
+  allowUnsafeOutputPath?: boolean;
   apiBase: string;
   baseDir: string;
   excalidraw?: ExcalidrawFile;
@@ -358,6 +360,7 @@ async function resolveExcalidraw(input: DiagramGradeInput): Promise<{
 
 async function ensurePng(
   excalidraw: ExcalidrawFile | null,
+  context: { sessionID: string },
   input: DiagramGradeInput
 ): Promise<{
   pngPath: string | null;
@@ -365,7 +368,7 @@ async function ensurePng(
   pngDurationMs?: number;
 }> {
   if (input.pngPath) {
-    return { pngPath: resolveOutputPath(input.pngPath, input.baseDir) };
+    return { pngPath: resolve(input.baseDir, input.pngPath) };
   }
 
   if (!excalidraw) {
@@ -373,8 +376,10 @@ async function ensurePng(
   }
 
   const outputPath = input.outputPath
-    ? resolveOutputPath(input.outputPath, input.baseDir)
-    : buildDefaultPngPath("diagram-grade", input.baseDir);
+    ? resolveOutputPath(input.outputPath, input.baseDir, context.sessionID, {
+        allowUnsafeOutputPath: input.allowUnsafeOutputPath,
+      })
+    : buildDefaultPngPath("diagram-grade", input.baseDir, context.sessionID);
 
   const pngResult = await renderElementsToPng(
     excalidraw.elements,
@@ -425,7 +430,7 @@ export async function gradeDiagram(
   let pngDurationMs: number | undefined;
 
   try {
-    const pngResult = await ensurePng(resolved.excalidraw, input);
+    const pngResult = await ensurePng(resolved.excalidraw, context, input);
     pngPath = pngResult.pngPath;
     pngBytes = pngResult.pngBytes;
     pngDurationMs = pngResult.pngDurationMs;

--- a/packages/opencode-excalidraw/src/lib/output.test.ts
+++ b/packages/opencode-excalidraw/src/lib/output.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { relative, resolve } from "node:path";
+
+import {
+  buildDefaultPngPath,
+  resolveOutputPath,
+  resolveSessionPngOutputRoot,
+} from "./output";
+
+const BASE_DIR = resolve(process.cwd(), "tmp-output-policy");
+
+describe("output path policy", () => {
+  test("buildDefaultPngPath writes under session-scoped .sketchi root", () => {
+    const outputPath = buildDefaultPngPath("diagram", BASE_DIR, "session-123");
+    const root = resolveSessionPngOutputRoot(BASE_DIR, "session-123");
+    const relativePath = relative(root, outputPath);
+
+    expect(relativePath.startsWith("..")).toBe(false);
+    expect(relativePath).not.toBe("");
+    expect(outputPath.endsWith(".png")).toBe(true);
+  });
+
+  test("resolveOutputPath keeps bare filenames inside session root", () => {
+    const resolved = resolveOutputPath("diagram.png", BASE_DIR, "session-1");
+    const root = resolveSessionPngOutputRoot(BASE_DIR, "session-1");
+
+    expect(resolved).toBe(resolve(root, "diagram.png"));
+  });
+
+  test("resolveOutputPath keeps nested relative paths inside session root", () => {
+    const resolved = resolveOutputPath(
+      "exports/diagram.png",
+      BASE_DIR,
+      "session-2"
+    );
+    const root = resolveSessionPngOutputRoot(BASE_DIR, "session-2");
+
+    expect(resolved).toBe(resolve(root, "exports/diagram.png"));
+  });
+
+  test("resolveOutputPath accepts absolute paths only when already in session root", () => {
+    const root = resolveSessionPngOutputRoot(BASE_DIR, "session-3");
+    const allowedAbsolute = resolve(root, "exports", "diagram.png");
+
+    expect(resolveOutputPath(allowedAbsolute, BASE_DIR, "session-3")).toBe(
+      allowedAbsolute
+    );
+  });
+
+  test("resolveOutputPath rejects traversal attempts by default", () => {
+    expect(() =>
+      resolveOutputPath("../escape.png", BASE_DIR, "session-4")
+    ).toThrow("must stay within");
+  });
+
+  test("resolveOutputPath rejects absolute paths outside session root by default", () => {
+    const outsideAbsolute = resolve(BASE_DIR, "..", "outside.png");
+    expect(() =>
+      resolveOutputPath(outsideAbsolute, BASE_DIR, "session-5")
+    ).toThrow("must stay within");
+  });
+
+  test("resolveOutputPath opt-out allows paths outside session root", () => {
+    const resolved = resolveOutputPath("../escape.png", BASE_DIR, "session-6", {
+      allowUnsafeOutputPath: true,
+    });
+
+    expect(resolved).toBe(resolve(BASE_DIR, "../escape.png"));
+  });
+
+  test("session output root sanitizes session IDs for safe directory names", () => {
+    const root = resolveSessionPngOutputRoot(BASE_DIR, "session/../:weird");
+    expect(root).toBe(
+      resolve(BASE_DIR, ".sketchi", "sessions", "session_..__weird", "png")
+    );
+  });
+});

--- a/packages/opencode-excalidraw/src/lib/output.ts
+++ b/packages/opencode-excalidraw/src/lib/output.ts
@@ -1,19 +1,85 @@
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 
-export const DEFAULT_OUTPUT_DIR = "sketchi/png";
+export const DEFAULT_OUTPUT_DIR = ".sketchi/sessions";
+const DEFAULT_PNG_SUBDIR = "png";
+const DEFAULT_SESSION_ID = "unknown-session";
 
-export function resolveOutputPath(path: string, baseDir: string): string {
-  return resolve(baseDir, path);
+interface ResolveOutputPathOptions {
+  allowUnsafeOutputPath?: boolean;
+}
+
+function normalizeSessionIdForPath(sessionID: string): string {
+  const trimmed = sessionID.trim();
+  if (!trimmed) {
+    return DEFAULT_SESSION_ID;
+  }
+
+  const normalized = trimmed.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return normalized.length > 0 ? normalized : DEFAULT_SESSION_ID;
+}
+
+export function resolveSessionPngOutputRoot(
+  baseDir: string,
+  sessionID: string
+): string {
+  return resolve(
+    baseDir,
+    DEFAULT_OUTPUT_DIR,
+    normalizeSessionIdForPath(sessionID),
+    DEFAULT_PNG_SUBDIR
+  );
+}
+
+function isPathWithinRoot(candidatePath: string, root: string): boolean {
+  const relativePath = relative(root, candidatePath);
+  if (relativePath === "") {
+    return true;
+  }
+
+  return !(relativePath.startsWith("..") || isAbsolute(relativePath));
+}
+
+export function resolveOutputPath(
+  path: string,
+  baseDir: string,
+  sessionID: string,
+  options: ResolveOutputPathOptions = {}
+): string {
+  const normalizedPath = path.trim();
+  if (!normalizedPath) {
+    throw new Error("outputPath must not be empty.");
+  }
+
+  if (options.allowUnsafeOutputPath) {
+    return resolve(baseDir, normalizedPath);
+  }
+
+  const outputRoot = resolveSessionPngOutputRoot(baseDir, sessionID);
+  const resolvedPath = isAbsolute(normalizedPath)
+    ? resolve(normalizedPath)
+    : resolve(outputRoot, normalizedPath);
+
+  if (!isPathWithinRoot(resolvedPath, outputRoot)) {
+    throw new Error(
+      `outputPath must stay within ${outputRoot}. Set SKETCHI_ALLOW_UNSAFE_OUTPUT_PATH=1 to allow paths outside this directory.`
+    );
+  }
+
+  return resolvedPath;
 }
 
 function formatTimestamp(date: Date): string {
   return date.toISOString().replace(/[:.]/g, "-");
 }
 
-export function buildDefaultPngPath(prefix: string, baseDir: string): string {
-  const folder = resolve(baseDir, DEFAULT_OUTPUT_DIR);
+export function buildDefaultPngPath(
+  prefix: string,
+  baseDir: string,
+  sessionID: string
+): string {
+  const folder = resolveSessionPngOutputRoot(baseDir, sessionID);
   const filename = `${prefix}-${formatTimestamp(new Date())}-${randomUUID().slice(0, 8)}.png`;
   return resolve(folder, filename);
 }


### PR DESCRIPTION
Closes #186

## Summary
- move default plugin PNG output root from `/sketchi/png` to `/.sketchi/sessions/<sessionID>/png`
- enforce default `outputPath` containment under the session root for all diagram write tools
- add explicit power-user opt-out via `SKETCHI_ALLOW_UNSAFE_OUTPUT_PATH=1`
- add targeted tests for session-scoped pathing + traversal/containment + opt-out behavior
- update plugin docs and integration scenario expectations to match the new output policy

## Scope Implemented (from #186)
1. **Default output root migration**
- `buildDefaultPngPath` now writes under `.sketchi/sessions/<sessionID>/png`
- all write paths now pass `context.sessionID` to default pathing

2. **Containment enforcement**
- `resolveOutputPath` now enforces in-root writes by default
- bare filename and nested relative paths are normalized under session root
- absolute paths outside root and traversal (`..`) attempts are rejected by default
- opt-out: `SKETCHI_ALLOW_UNSAFE_OUTPUT_PATH=1` restores base-dir resolution

3. **Git ignore hygiene**
- root `.gitignore` now ignores `/.sketchi/`

4. **Automated coverage**
- new `src/lib/output.test.ts` validates:
  - default session-scoped path generation
  - containment success cases (bare, nested, in-root absolute)
  - containment reject cases (traversal, out-of-root absolute)
  - opt-out behavior

5. **Docs consistency**
- `packages/opencode-excalidraw/README.md` now documents output-root behavior and opt-out
- integration scenario comments/assertions now expect `.sketchi/sessions/<sessionID>/png`

## Notes
- `diagram_grade` keeps `pngPath` behavior as file input path resolution (read path), while `outputPath` write behavior is constrained per policy.

## Local Validation
- `cd packages/opencode-excalidraw && bun run test` ✅
- `cd packages/opencode-excalidraw && bun run typecheck && bun run build` ✅
- `bun x ultracite fix` ✅
- `bun x ultracite check` ✅
- `bun run check-types` ✅
- `bun run build` ✅
- `cd packages/backend && bunx convex codegen && bun run test` ✅
