### PR TITLE
fix(auth): accept active WorkOS client during Convex deploy

### DIFF
--- a/packages/backend/convex/auth.config.test.ts
+++ b/packages/backend/convex/auth.config.test.ts
@@ -1,0 +1,29 @@
+import { beforeAll, describe, expect, test } from "vitest";
+
+let buildWorkOsClientIds: (primaryClientId: string) => string[];
+
+beforeAll(async () => {
+  process.env.WORKOS_CLIENT_ID = "client_current";
+  ({ buildWorkOsClientIds } = await import("./auth.config"));
+});
+
+describe("buildWorkOsClientIds", () => {
+  test("keeps the primary client id first", () => {
+    expect(buildWorkOsClientIds("client_current")).toEqual(["client_current"]);
+  });
+
+  test("accepts current production tokens when Convex still has the preview client", () => {
+    expect(buildWorkOsClientIds("client_01KFPXKM905BYDQY5Q7BFJN409")).toEqual([
+      "client_01KFPXKM905BYDQY5Q7BFJN409",
+      "client_01KG0NPZN3AWXNTRHC58VAPVW2",
+    ]);
+  });
+
+  test("accepts preview and production tokens when Convex still has the legacy preview client", () => {
+    expect(buildWorkOsClientIds("client_01KG0NZ3QX0AJQE87CKZC74YXQ")).toEqual([
+      "client_01KG0NZ3QX0AJQE87CKZC74YXQ",
+      "client_01KFPXKM905BYDQY5Q7BFJN409",
+      "client_01KG0NPZN3AWXNTRHC58VAPVW2",
+    ]);
+  });
+});

--- a/packages/backend/convex/auth.config.ts
+++ b/packages/backend/convex/auth.config.ts
@@ -8,20 +8,30 @@ if (!clientId) {
 
 const previewWorkOsClientId = "client_01KFPXKM905BYDQY5Q7BFJN409";
 const legacyPreviewAuthConfigClientId = "client_01KG0NZ3QX0AJQE87CKZC74YXQ";
+const productionWorkOsClientId = "client_01KG0NPZN3AWXNTRHC58VAPVW2";
 
-const clientIds = Array.from(
-  new Set(
-    [
-      clientId,
-      // Convex auth config only permits env vars already set in Convex.
-      // During preview deploys, auth config currently sees the legacy client
-      // while Vercel/WorkOS mint tokens for the newer preview client.
-      clientId === legacyPreviewAuthConfigClientId
-        ? previewWorkOsClientId
-        : null,
-    ].filter((value): value is string => Boolean(value))
-  )
-);
+export function buildWorkOsClientIds(primaryClientId: string): string[] {
+  return Array.from(
+    new Set(
+      [
+        primaryClientId,
+        // Convex auth config can see the previously stored client during the
+        // same deploy that refreshes WorkOS/Vercel credentials. Keep the
+        // active handoff clients valid so first deploys do not reject fresh
+        // AuthKit tokens.
+        primaryClientId === legacyPreviewAuthConfigClientId
+          ? previewWorkOsClientId
+          : null,
+        primaryClientId === legacyPreviewAuthConfigClientId ||
+        primaryClientId === previewWorkOsClientId
+          ? productionWorkOsClientId
+          : null,
+      ].filter((value): value is string => Boolean(value))
+    )
+  );
+}
+
+const clientIds = buildWorkOsClientIds(clientId);
 
 export default {
   providers: clientIds.flatMap((currentClientId) => {


### PR DESCRIPTION
## Summary
- include the active production WorkOS client when Convex still reads older preview client ids during deploy
- add focused coverage for WorkOS client-id expansion

## Verification
- bunx vitest run convex/auth.config.test.ts --reporter=default
- cd packages/backend && bun run test
- bun x ultracite fix
- bun run check-types
- NEXT_PUBLIC_CONVEX_URL=https://impartial-rat-992.convex.cloud bun run build

## Production note
- manually redeployed Vercel production so www.sketchi.app now points at https://impartial-rat-992.convex.cloud, whose WorkOS client id is client_01KG0NPZN3AWXNTRHC58VAPVW2